### PR TITLE
Add more option helpers to Curl.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ All methods
     
     // set data to be sent via POST. For this to work usePost() should be set to true
     function setStringPostData(string $data)
+
+    // set the port number which will be used for the request
+    function setPort(int $port)
+
+    // set the max number of redirects that this request will follow
+    function setMaxRedirects(int $max)
+
+    // set the timeout for this request (in seconds)
+    function setTimeout(int $timeout)
+
+    // set the username and password to be used for HTTP authentication
+    function setCredentials(string $username, string $password)
+
+    // set any valid CURL option in case a helper method isn't present
+    function setOption(int $option, mixed $value)
     
     // Call this after setting all url, headers, method & data
     function execute()

--- a/src/Curl.php
+++ b/src/Curl.php
@@ -85,6 +85,53 @@ class Curl
         curl_setopt($this->curl, CURLOPT_POSTFIELDS, $data);
     }
 
+    /**
+     * set port to be used for request
+     * @param int $port
+     */
+    public function setPort(int $port)
+    {
+        curl_setopt($this->curl, CURLOPT_PORT, $port);
+    }
+
+    /**
+     * set the max number of redirects that will be followed
+     * @param int $max
+     */
+    public function setMaxRedirects(int $max)
+    {
+        curl_setopt($this->curl, CURLOPT_MAXREDIRS, $max);
+    }
+
+    /**
+     * set timeout for request
+     * @param int $timeout time in seconds
+     */
+    public function setTimeout(int $timeout)
+    {
+        curl_setopt($this->curl, CURLOPT_TIMEOUT, $timeout);
+    }
+
+    /**
+     * set the credentials used for HTTP authentication
+     * @param string $username
+     * @param string $password
+     */
+    public function setCredentials(string $username, string $password)
+    {
+        $userpwd = $username . ':' . $password;
+        curl_setopt($this->curl, CURLOPT_USERPWD, $userpwd);
+    }
+
+    /**
+     * set any CURLOPT_XXX option
+     * @param int $option
+     * @param mixed $value
+     */
+    public function setOption(int $option, mixed $value)
+    {
+        curl_setopt($this->curl, $option, $value);
+    }
 
     /**
      *Execute the curl request and store the results


### PR DESCRIPTION
This is in reference to Issue #9 

This simply adds the following options to the Curl helper class:

```php
    // set the port number which will be used for the request
    function setPort(int $port)

    // set the max number of redirects that this request will follow
    function setMaxRedirects(int $max)

    // set the timeout for this request (in seconds)
    function setTimeout(int $timeout)

    // set the username and password to be used for HTTP authentication
    function setCredentials(string $username, string $password)

    // set any valid CURL option in case a helper method isn't present
    function setOption(int $option, mixed $value)
```